### PR TITLE
Add I18n.lang

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,10 @@ const ACCEPT_LANG: &'static str = "Accept-Language";
 
 /// A request guard to get the right translation catalog for the current request.
 pub struct I18n {
-	/// The catalog containing the translated messages, in the correct locale for this request.
+    /// The catalog containing the translated messages, in the correct locale for this request.
     pub catalog: Catalog,
+    /// The language of the current request.
+    pub lang: &'static str,
 }
 
 pub type Translations = Vec<(&'static str, Catalog)>;

--- a/src/with_actix.rs
+++ b/src/with_actix.rs
@@ -55,8 +55,9 @@ where
             .unwrap_or("en");
 
         match langs.iter().find(|l| l.0 == lang) {
-            Some(catalog) => Ok(I18n {
-                catalog: catalog.1.clone(),
+            Some(translation) => Ok(I18n {
+                catalog: translation.1.clone(),
+                lang: translation.0,
             }),
             None => Err(MissingTranslationsError(lang.to_owned()).into()),
         }

--- a/src/with_rocket.rs
+++ b/src/with_rocket.rs
@@ -28,8 +28,9 @@ impl<'a, 'r> FromRequest<'a, 'r> for I18n {
             .unwrap_or("en");
 
         match langs.iter().find(|l| l.0 == lang) {
-            Some(catalog) => Outcome::Success(I18n {
-                catalog: catalog.1.clone(),
+            Some(translation) => Outcome::Success(I18n {
+                catalog: translation.1.clone(),
+                lang: translation.0,
             }),
             None => Outcome::Failure((Status::InternalServerError, ())),
         }


### PR DESCRIPTION
Used to get the language for the current request. It can be used for database requests or to adapt the UI.

It should be backwards compatible, except when pattern matching is used (`let I18n { catalog } = i18n`) which is unlikely.